### PR TITLE
Add FlashStringHelper

### DIFF
--- a/Arduban/FlashStringHelper.h
+++ b/Arduban/FlashStringHelper.h
@@ -1,0 +1,67 @@
+#pragma once
+
+//
+// Copyright (C) 2019 Pharap (@Pharap)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Include __FlashStringHelper
+#include <WString.h>
+
+//
+// FlashStringHelper
+//
+
+using FlashStringHelper = const __FlashStringHelper *;
+
+//
+// asFlashStringHelper
+//
+
+inline FlashStringHelper asFlashStringHelper(const char * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(static_cast<const void *>(flashString));
+}
+
+inline FlashStringHelper asFlashStringHelper(const unsigned char * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(static_cast<const void *>(flashString));
+}
+
+inline FlashStringHelper asFlashStringHelper(const signed char * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(static_cast<const void *>(flashString));
+}
+
+// Include pgm_read_ptr
+#include <avr/pgmspace.h>
+
+//
+// readFlashString
+//
+
+inline FlashStringHelper readFlashStringPointer(const char * const * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(pgm_read_ptr(flashString));
+}
+
+inline FlashStringHelper readFlashStringPointer(const unsigned char * const * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(pgm_read_ptr(flashString));
+}
+
+inline FlashStringHelper readFlashStringPointer(const signed char * const * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(pgm_read_ptr(flashString));
+}

--- a/Arduban/encourage.cpp
+++ b/Arduban/encourage.cpp
@@ -2,7 +2,7 @@
 
 #define MAX_ENCOURAGE 20
 
-char encouragement[14];
+FlashStringHelper encouragement;
 
 const char string_01[] PROGMEM = "Stupendous";
 const char string_02[] PROGMEM = "Magnificent";
@@ -35,10 +35,10 @@ const char* const encouragements[] PROGMEM = {
 void setRandomEncouragement()
 {
     uint8_t r = random(0, MAX_ENCOURAGE);
-    strcpy_P(encouragement, (char *)pgm_read_word(&(encouragements[r])));
+    encouragement = readFlashStringPointer(&encouragements[r]);
 }
 
-const char * getRandomEncouragment()
+FlashStringHelper getRandomEncouragment()
 {
     return encouragement;
 }

--- a/Arduban/encourage.h
+++ b/Arduban/encourage.h
@@ -2,8 +2,9 @@
 #define ENCOURAGE_H
 
 #include "globals.h"
+#include "FlashStringHelper.h"
 
 void setRandomEncouragement();
-const char * getRandomEncouragment();
+FlashStringHelper getRandomEncouragment();
 
 #endif

--- a/Arduban/game.cpp
+++ b/Arduban/game.cpp
@@ -132,11 +132,11 @@ void explode()
 void undo(int8_t x, int8_t y, bool push)
 {
 #if DEBUG
-    Serial.print("Undo x=");
+    Serial.print(F("Undo x=");
     Serial.print(x);
-    Serial.print(", y=");
+    Serial.print(F(", y=");
     Serial.print(y);
-    Serial.print(", p=");
+    Serial.print(F(", p=");
     Serial.println(push);
 #endif
 
@@ -159,7 +159,7 @@ void undo(int8_t x, int8_t y, bool push)
     default:
         // This should never happen!
 #if DEBUG
-        Serial.print("Invalid square ");
+        Serial.print(F("Invalid square ");
         Serial.println(board[r][c]);
 #endif
         return;
@@ -194,7 +194,7 @@ void printUndo(byte move)
 {
     if(move == 0x00)
     {
-        Serial.print("--");
+        Serial.print(F("--");
         return;
     }
     Serial.print((move & PUSH) == PUSH ? 'P' : 'M');
@@ -212,17 +212,17 @@ void printUndo(byte move)
 void undo()
 {
 #if DEBUG
-    Serial.println("Undo buffer;");
+    Serial.println(F("Undo buffer;");
     for(int i = 0; i < MAX_UNDO; i++)
     {
         printUndo(undoBuffer[i]);
-        Serial.print(", ");
+        Serial.print(F(", ");
     }
     Serial.println();
 
-    Serial.print("Undo move ");
+    Serial.print(F("Undo move ");
     Serial.print(moves % MAX_UNDO);
-    Serial.print(", ");
+    Serial.print(F(", ");
     printUndo(undoBuffer[moves % MAX_UNDO]);
     Serial.println();
 #endif

--- a/Arduban/globals.cpp
+++ b/Arduban/globals.cpp
@@ -25,7 +25,7 @@ byte board[ROWS][COLUMNS];
 // Helper function to dump a byte as a hex value to Serial
 void printHex(byte b)
 {
-    Serial.print(b < 0x10 ? "0x0" : "0x");
+    Serial.print(b < 0x10 ? F("0x0") : F("0x"));
     Serial.print(b, HEX);
 }
 

--- a/Arduban/intro.cpp
+++ b/Arduban/intro.cpp
@@ -29,19 +29,19 @@ void gameIntro()
     sprites.drawSelfMasked(8, 35, ManAndBox, 0);
 
     font4x6.setCursor(77, 40);
-    font4x6.print("Level ");
+    font4x6.print(F("Level "));
     font4x6.print(level);
 
     font4x6.setCursor(83, 48);
     uint16_t moves = getMoves(level);
     if(moves == 0xFFFF)
     {
-        font4x6.print("Unsolved");
+        font4x6.print(F("Unsolved"));
     }
     else
     {
         font4x6.print(moves);
-        font4x6.print(" moves");
+        font4x6.print(F(" moves"));
     }
 
     if(arduboy.justPressed(A_BUTTON))

--- a/Arduban/over.cpp
+++ b/Arduban/over.cpp
@@ -13,10 +13,10 @@ void gameOver()
     font4x6.print(getRandomEncouragment());
 
     font4x6.setCursor(8, 13);
-    font4x6.println("All levels complete!");
+    font4x6.println(F("All levels complete!"));
 
     font4x6.setCursor(8, 23);
-    font4x6.println("Improve your scores?");
+    font4x6.println(F("Improve your scores?"));
 
     if(arduboy.justPressed(A_BUTTON))
         gameState = STATE_GAME_INTRO;

--- a/Arduban/settings.cpp
+++ b/Arduban/settings.cpp
@@ -19,25 +19,25 @@ void clearSettings()
 void settings()
 {
     font4x6.setCursor(0, 10);
-    font4x6.println("Settings");
+    font4x6.println(F("Settings"));
 
     font4x6.setCursor(5, 28);
     font4x6.print(setting == 0 ? '>' : ' ');
-    font4x6.print("Turn sound ");
+    font4x6.print(F("Turn sound "));
     if(arduboy.audio.enabled())
-        font4x6.print("off");
+        font4x6.print(F("off"));
     else
-        font4x6.print("on");
+        font4x6.print(F("on"));
 
 
     font4x6.setCursor(5, 38);
     font4x6.print(setting == 1 ? '>' : ' ');
-    font4x6.print("Clear all scores");
+    font4x6.print(F("Clear all scores"));
 
     if(confirm)
     {
         font4x6.setCursor(5, 56);
-        font4x6.print("Are you sure?");
+        font4x6.print(F("Are you sure?"));
     }
 
     if(arduboy.justPressed(A_BUTTON))

--- a/Arduban/solved.cpp
+++ b/Arduban/solved.cpp
@@ -11,13 +11,13 @@ void levelSolved()
 
     font4x6.setCursor(8, 13);
     font4x6.print(moves);
-    font4x6.print(" moves for level ");
+    font4x6.print(F(" moves for level "));
     font4x6.print(level);
 
     if(bestScore != 0xFFFF)
     {
         font4x6.setCursor(8, 23);
-        font4x6.print("Previous best was ");
+        font4x6.print(F("Previous best was "));
         font4x6.print(bestScore);
     }
 


### PR DESCRIPTION
Feel free to reject this change if you feel the costs outweigh the benefits.

These changes make sure all strings are stored in progmem/flash rather than in RAM,
thus freeing up a large chunk of RAM.

The increase in progmem usage is because it causes `Print::print(const __FlashStringHelper *)` to be included in the code.

I was hoping it would cause `Print::print(const char *)` to be excluded from the code,
but I suspect some other overload of `Print::print(int)` uses that 'under the hood'.
Either that or I've missed something somewhere.

**Before**:
> Sketch uses 28410 bytes (99%) of program storage space. Maximum is 28672 bytes.
Global variables use 1697 bytes (66%) of dynamic memory, leaving 863 bytes for local variables. Maximum is 2560 bytes.

**After**:
> Sketch uses 28462 bytes (99%) of program storage space. Maximum is 28672 bytes.
Global variables use 1523 bytes (59%) of dynamic memory, leaving 1037 bytes for local variables. Maximum is 2560 bytes.