### PR TITLE
Improve loadLevel size and efficiency

### DIFF
--- a/Arduban/load.cpp
+++ b/Arduban/load.cpp
@@ -3,12 +3,15 @@
 #include "memory.h"
 #include "game.h"
 
+// For uint8_t
+#include <stdint.h>
+
 // Finds the player in the new board
 void findPlayer()
 {
-    for(int8_t r = 0; r < ROWS; r++)
+    for(uint8_t r = 0; r < ROWS; r++)
     {
-        for(int8_t c = 0; c < COLUMNS; c++)
+        for(uint8_t c = 0; c < COLUMNS; c++)
         {
             if(board[r][c] == PLAYER || board[r][c] == PLAYER_ON_GOAL)
             {
@@ -22,29 +25,29 @@ void findPlayer()
 
 void loadLevel()
 {
+    const uint8_t * levelData = static_cast<const uint8_t *>(pgm_read_ptr(&levels[level - 1]));
+
     uint8_t row = 0;
-    uint8_t col = 0;
-    uint8_t i = 0;
-    char b;
-    const __FlashStringHelper * buff = (__FlashStringHelper*)pgm_read_word(&(levels[level-1]));
+    uint8_t column = 0;
 
-    memcpy_P(&b, (PGM_P)buff, 1);
-    while(b != 0x00)
+    for(uint8_t data = pgm_read_byte(levelData); data != 0; data = pgm_read_byte(levelData))
     {
-        i++;
-        if(col >= COLUMNS)
+        if(column >= COLUMNS)
         {
-            row++;
-            col = 0;
+            ++row;
+            column = 0;
         }
 
-        byte count = (b & 0xF0) >> 4;
-        byte tile  = b & 0x0F;
-        for(byte i = 0; i <= count; i++)
+        const uint8_t count = ((data >> 4) & 0x0F);
+        const uint8_t tile  = ((data >> 0) & 0x0F);
+
+        for(uint8_t i = 0; i <= count; ++i)
         {
-            board[row][col++] = tile;
+            board[row][column] = tile;
+            ++column;
         }
-        memcpy_P(&b, (PGM_P)buff + i, 1);
+
+        ++levelData;
     }
 
     findPlayer();


### PR DESCRIPTION
Saves 96 bytes of progmem.

**Before**:
> Sketch uses 28462 bytes (99%) of program storage space. Maximum is 28672 bytes.
Global variables use 1523 bytes (59%) of dynamic memory, leaving 1037 bytes for local variables. Maximum is 2560 bytes.

**After**:
> Sketch uses 28366 bytes (98%) of program storage space. Maximum is 28672 bytes.
Global variables use 1523 bytes (59%) of dynamic memory, leaving 1037 bytes for local variables. Maximum is 2560 bytes.

I doubt I've done anything you couldn't have figured out on your own,
though I've probably done it slightly differently to how you would have.

`pgm_read_byte` is naturally smaller and cheaper than `memcpy_P`.
The `(PGM_P)` cast was never needed in the first place because `memcpy_P` accepts `void *`s,
and all pointers are implicitly convertible to `void *`.
Nor was `const __FlashStringHelper *` needed, because as I explained in my last PR,
`__FlashStringHelper` only exists as a convinience for function overloading with strings.

Originally I kept `i` (though renamed it `index`), but I discovered that the code is actually cheaper if you get rid of it and use pointer incrementing, which is strange because normally it doesn't make a difference and the compiler translates it to whichever is the more efficient option.
My only guess is that perhaps the assembly used in the `pgm_read_byte` macro upsets the compiler and prevents it from making the optimisation.

While I was at it I got rid of `byte` in favour of `uint8_t` because `byte` is a non-standard type alias for `uint8_t` introduced by Arduino, while `uint8_t` is more standard.

`pgm_read_ptr` should be preferred over `pgm_read_word` for reading pointers because it's a better expression of intent and it evaluates to a `const void *`, which in turn allows `static_cast` to be used, and `static_cast` is typically safer and more predictable than `reinterpret_cast`.
Also if other systems were supported then the size of a pointer might not necessarily be the size of a word (much like how `uintptr_t` should be used for storing a pointer as an integer because `int` may not be large enough).

And lastly, while I was at it I changed the `int8_t`s to `uint8_t` in the previous function because it doesn't really make sense to access an array with signed integer types.
Strictly speaking you should use `size_t` for indexing arrays,
but most unsigned types are acceptable if the range is adequate.
Also sometimes unsigned types are cheaper. Not in this case, but in some cases.